### PR TITLE
Ignore nameplates

### DIFF
--- a/movable.lua
+++ b/movable.lua
@@ -1006,6 +1006,7 @@ SlashCmdList[slashGlobal] = function(inp)
 	else
 		if(not _LOCK) then
 			for k, obj in next, oUF.objects do
+				if(obj.isNamePlate) then return end -- bail out on nameplates since we can't move those
 				if(not obj.disableMovement) then
 					local style, identifier, isHeader = getObjectInformation(obj)
 					local backdrop = getBackdrop(obj, isHeader)

--- a/movable.lua
+++ b/movable.lua
@@ -1006,8 +1006,7 @@ SlashCmdList[slashGlobal] = function(inp)
 	else
 		if(not _LOCK) then
 			for k, obj in next, oUF.objects do
-				if(obj.isNamePlate) then return end -- bail out on nameplates since we can't move those
-				if(not obj.disableMovement) then
+				if(not obj.disableMovement and not obj.isNamePlate) then
 					local style, identifier, isHeader = getObjectInformation(obj)
 					local backdrop = getBackdrop(obj, isHeader)
 					if(backdrop) then backdrop:Show() end


### PR DESCRIPTION
This is a small PR to ignore units that are nameplates (oUF sets property .isNamePlate).
Movable frames errors when the Unit Frame is a nameplate since some methods from Blizzard are protected (getting measures for instance).

By bailing out of nameplates and since we can't really move them anyway, this fixes it.