### PR TITLE
Options panel fixes

### DIFF
--- a/movable.lua
+++ b/movable.lua
@@ -714,14 +714,6 @@ do
 				editbox:SetPoint('TOP', 0, -4)
 				editbox:SetPoint('BOTTOM', 0, 0)
 
-				local background = editbox:CreateTexture(nil, 'BACKGROUND')
-				background:SetPoint('TOP', 0, -1)
-				background:SetPoint'LEFT'
-				background:SetPoint'RIGHT'
-				background:SetPoint('BOTTOM', 0, 4)
-
-				background:SetTexture(1, 1, 1, .05)
-
 				editbox:SetScript('OnEscapePressed', OnEscapePressed)
 				editbox:SetScript('OnEnterPressed', OnEnterPressed)
 				editbox:SetScript('OnEditFocusGained', OnEditFocusGained)

--- a/movable.lua
+++ b/movable.lua
@@ -561,20 +561,17 @@ do
 		subtitle:SetJustifyH'LEFT'
 		subtitle:SetFormattedText('Type %s to toggle frame anchors.', _G['SLASH_' .. slashGlobal .. 1])
 
-		local scroll = CreateFrame("ScrollFrame", nil, self)
+		local scroll = CreateFrame('ScrollFrame', nil, self, 'UIPanelScrollFrameTemplate')
 		scroll:SetPoint('TOPLEFT', subtitle, 'BOTTOMLEFT', 0, -8)
-		scroll:SetPoint("BOTTOMRIGHT", 0, 4)
+		scroll:SetPoint("BOTTOMRIGHT", -27, 4)
 
 		local scrollchild = CreateFrame("Frame", nil, self)
-		scrollchild:SetPoint"LEFT"
-		scrollchild:SetHeight(scroll:GetHeight())
-		scrollchild:SetWidth(scroll:GetWidth())
+		scrollchild:SetHeight(1)
+		scrollchild:SetWidth(InterfaceOptionsFramePanelContainer:GetWidth() - 18)
 
 		scroll:SetScrollChild(scrollchild)
 		scroll:UpdateScrollChildRect()
 		scroll:EnableMouseWheel(true)
-
-		local slider = CreateFrame("Slider", nil, scroll)
 
 		local backdrop = {
 			bgFile = [[Interface\ChatFrame\ChatFrameBackground]], tile = true, tileSize = 16,
@@ -585,7 +582,6 @@ do
 		local createOrUpdateMadnessOfGodIhateGUIs
 		local OnClick = function(self)
 			local row = self:GetParent()
-			scroll.value = slider:GetValue()
 			_DB[row.style][row.ident] = nil
 
 			if(not next(_DB[row.style])) then
@@ -896,76 +892,7 @@ do
 			end
 
 			self.data = data
-			local height = slideHeight - scroll:GetHeight()
-			if(height > 0) then
-				slider:SetMinMaxValues(0, height)
-			else
-				slider:SetMinMaxValues(0, 0)
-			end
-
-			slider:SetValue(scroll.value or 0)
 		end
-
-		slider:SetWidth(16)
-
-		slider:SetPoint("TOPRIGHT", -8, -24)
-		slider:SetPoint("BOTTOMRIGHT", -8, 24)
-
-		local up = CreateFrame("Button", nil, slider)
-		up:SetPoint("BOTTOM", slider, "TOP")
-		up:SetWidth(16)
-		up:SetHeight(16)
-		up:SetNormalTexture("Interface\\Buttons\\UI-ScrollBar-ScrollUpButton-Up")
-		up:SetPushedTexture("Interface\\Buttons\\UI-ScrollBar-ScrollUpButton-Down")
-		up:SetDisabledTexture("Interface\\Buttons\\UI-ScrollBar-ScrollUpButton-Disabled")
-		up:SetHighlightTexture("Interface\\Buttons\\UI-ScrollBar-ScrollUpButton-Highlight")
-
-		up:GetNormalTexture():SetTexCoord(1/4, 3/4, 1/4, 3/4)
-		up:GetPushedTexture():SetTexCoord(1/4, 3/4, 1/4, 3/4)
-		up:GetDisabledTexture():SetTexCoord(1/4, 3/4, 1/4, 3/4)
-		up:GetHighlightTexture():SetTexCoord(1/4, 3/4, 1/4, 3/4)
-		up:GetHighlightTexture():SetBlendMode("ADD")
-
-		up:SetScript("OnClick", function(self)
-			local box = self:GetParent()
-			box:SetValue(box:GetValue() - box:GetHeight()/2)
-		end)
-
-		local down = CreateFrame("Button", nil, slider)
-		down:SetPoint("TOP", slider, "BOTTOM")
-		down:SetWidth(16)
-		down:SetHeight(16)
-		down:SetNormalTexture("Interface\\Buttons\\UI-ScrollBar-ScrollDownButton-Up")
-		down:SetPushedTexture("Interface\\Buttons\\UI-ScrollBar-ScrollDownButton-Down")
-		down:SetDisabledTexture("Interface\\Buttons\\UI-ScrollBar-ScrollDownButton-Disabled")
-		down:SetHighlightTexture("Interface\\Buttons\\UI-ScrollBar-ScrollDownButton-Highlight")
-
-		down:GetNormalTexture():SetTexCoord(1/4, 3/4, 1/4, 3/4)
-		down:GetPushedTexture():SetTexCoord(1/4, 3/4, 1/4, 3/4)
-		down:GetDisabledTexture():SetTexCoord(1/4, 3/4, 1/4, 3/4)
-		down:GetHighlightTexture():SetTexCoord(1/4, 3/4, 1/4, 3/4)
-		down:GetHighlightTexture():SetBlendMode("ADD")
-
-		down:SetScript("OnClick", function(self)
-			local box = self:GetParent()
-			box:SetValue(box:GetValue() + box:GetHeight()/2)
-		end)
-
-		slider:SetThumbTexture("Interface\\Buttons\\UI-ScrollBar-Knob")
-		local thumb = slider:GetThumbTexture()
-		thumb:SetWidth(16)
-		thumb:SetHeight(24)
-		thumb:SetTexCoord(1/4, 3/4, 1/8, 7/8)
-
-		slider:SetScript("OnValueChanged", function(self, val, ...)
-			local min, max = self:GetMinMaxValues()
-			if(val == min) then up:Disable() else up:Enable() end
-			if(val == max) then down:Disable() else down:Enable() end
-
-			scroll.value = val
-			scroll:SetVerticalScroll(val)
-			scrollchild:SetPoint('TOP', 0, val)
-		end)
 
 		opt:SetScript("OnShow", function()
 			return createOrUpdateMadnessOfGodIhateGUIs()

--- a/movable.lua
+++ b/movable.lua
@@ -72,14 +72,14 @@ local getPoint = function(obj, anchor)
 		end
 
 		return string.format(
-			'%s\031%s\031%d\031%d\031\%.3f',
+			'%s\031%s\031%d\031%d\031%.3f',
 			point, 'UIParent', x,  y, OS
 		)
 	else
 		local point, parent, _, x, y = anchor:GetPoint()
 
 		return string.format(
-			'%s\031%s\031%d\031%d\031\%.3f',
+			'%s\031%s\031%d\031%d\031%.3f',
 			point, 'UIParent', x, y, obj:GetScale()
 		)
 	end
@@ -223,7 +223,7 @@ local saveCustomPosition = function(style, ident, point, x, y, scale)
 	if(not _DB[style]) then _DB[style] = {} end
 
 	_DB[style][ident] = string.format(
-		'%s\031%s\031%d\031%d\031\%.3f',
+		'%s\031%s\031%d\031%d\031%.3f',
 		point, 'UIParent', x,  y, scale
 	)
 end

--- a/movable.lua
+++ b/movable.lua
@@ -711,8 +711,8 @@ do
 				editbox:SetAutoFocus(false)
 				editbox:SetFontObject(GameFontHighlight)
 
-				editbox:SetPoint('TOP', 0, -4)
-				editbox:SetPoint('BOTTOM', 0, 0)
+				editbox:SetPoint('TOP')
+				editbox:SetPoint('BOTTOM')
 
 				editbox:SetScript('OnEscapePressed', OnEscapePressed)
 				editbox:SetScript('OnEnterPressed', OnEnterPressed)
@@ -836,8 +836,6 @@ do
 
 							local unitLabel= row:CreateFontString(nil, nil, 'GameFontHighlight')
 							unitLabel:SetPoint('LEFT', 10, 0)
-							unitLabel:SetPoint('TOP', 0, -4)
-							unitLabel:SetPoint'BOTTOM'
 							unitLabel:SetJustifyH'LEFT'
 							row.unitLabel = unitLabel
 

--- a/movable.lua
+++ b/movable.lua
@@ -740,7 +740,7 @@ do
 							box:SetPoint('TOP', data[numStyles - 1], 'BOTTOM', 0, -16)
 						end
 						box:SetPoint'LEFT'
-						box:SetPoint('RIGHT', -30, 0)
+						box:SetPoint('RIGHT', scroll, 0, 0)
 
 						local title = box:CreateFontString(nil, 'ARTWORK', 'GameFontHighlight')
 						title:SetPoint('BOTTOMLEFT', box, 'TOPLEFT', 8, 0)


### PR DESCRIPTION
This fixes some visual annoyances in the options panel:

- removes editboxes' background (was rendering green textures)
- use `UIPanelScrollFrameTemplate` instead of custom sliders
- vertically center row texts (were pushed down by 4 pixels)
- right-anchor boxes to the scroll frame instead of the scroll child (makes them resize with options panel frame)